### PR TITLE
chore(regulus): ship bootstrap applicationset generator for argocd

### DIFF
--- a/base/builds/regulus/cloud-init/k8s-master/master-user-data.yaml.tftpl
+++ b/base/builds/regulus/cloud-init/k8s-master/master-user-data.yaml.tftpl
@@ -116,6 +116,11 @@ write_files:
         url: ${repository-url}
         sshPrivateKey: |
           ${indent(10,base64decode(argocd-ssh-private-key))}
+  - path: /etc/k8s-bootstrap/Application.bootstrap.yaml
+    owner: root:root
+    permissions: '0600'
+    encoding: b64
+    content: ${base64encode(bootstrap-application)}
 users:
   - default
   - name: tkjode
@@ -147,6 +152,7 @@ runcmd:
   - KUBECONFIG=/etc/kubernetes/admin.conf kubectl create namespace argocd
   - KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
   - KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -n argocd -f /etc/k8s-bootstrap/secret-argocd.yaml
+  - KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -n argocd -f /etc/k8s-bootstrap/Application.bootstrap.yaml
 %{ else }
   - kubeadm join --control-plane --token ${cluster-join-token} ${control-plane-endpoint}:6443 --discovery-token-ca-cert-hash sha256:$(cat /etc/kubernetes/pki/ca.crt | openssl x509 -pubkey | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //')
 %{ endif }

--- a/base/builds/regulus/vm-master-nodes.tf
+++ b/base/builds/regulus/vm-master-nodes.tf
@@ -57,6 +57,10 @@ resource "proxmox_virtual_environment_vm" "masters" {
   }
 }
 
+locals {
+  argocd-application-bootstrap = file("argocd/Application.bootstrap.yaml")
+}
+
 resource "proxmox_virtual_environment_file" "master-user-data-cloud-config" {
   count         = 3
   content_type  = "snippets"
@@ -85,6 +89,7 @@ resource "proxmox_virtual_environment_file" "master-user-data-cloud-config" {
                       sa-key                  = tls_private_key.sa-key.private_key_pem
                       argocd-ssh-private-key  = var.argocd-ssh-private-key
                       repository-url          = var.repository-url
+                      bootstrap-application   = local.argocd-application-bootstrap
                     }
                   )
   }


### PR DESCRIPTION
- Tested a simple cloud-init exec of the Bootstrap ArgoCD Applcation immediately after ArgoCD install and repo secret injection
- Rebuilt cluster
- Application came online within a few minutes, ApplicationSet sourced and created envoy and gateway-api additions to the cluster
- All bootstrap apps became Synced/Healthy within a few minutes.

> _Great Success_ 